### PR TITLE
Use edit_theme_options capability for menu

### DIFF
--- a/simple-custom-css.php
+++ b/simple-custom-css.php
@@ -143,7 +143,7 @@ add_action( 'template_redirect', 'sccss_trigger_check' );
  * @since 1.0
  */
 function sccss_register_submenu_page() {
-	add_theme_page( __( 'Simple Custom CSS', 'sccss' ), __( 'Custom CSS', 'sccss' ), 'edit_themes', basename(__FILE__), 'sccss_render_submenu_page' );
+	add_theme_page( __( 'Simple Custom CSS', 'sccss' ), __( 'Custom CSS', 'sccss' ), 'edit_theme_options', basename(__FILE__), 'sccss_render_submenu_page' );
 }
 
 add_action( 'admin_menu', 'sccss_register_submenu_page' );


### PR DESCRIPTION
In a multi-user system, the edit_themes capability is only available to
Super Admin. To allow a normal Administrator to access the Simple Custom
CSS menu item, we need it to be available to the edit_theme_options
capability.
