### PR TITLE
Allowing capability to be filtered.

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -69,7 +69,7 @@ add_action( 'admin_enqueue_scripts', 'sccss_register_codemirror' );
  * @since 1.0
  */
 function sccss_register_submenu_page() {
-	add_theme_page( __( 'Simple Custom CSS', 'sccss' ), __( 'Custom CSS', 'sccss' ), 'edit_theme_options', basename( SCCSS_FILE ), 'sccss_render_submenu_page' );
+	add_theme_page( __( 'Simple Custom CSS', 'sccss' ), __( 'Custom CSS', 'sccss' ), apply_filters( 'sccss_capability', 'edit_theme_options' ), basename( SCCSS_FILE ), 'sccss_render_submenu_page' );
 }
 add_action( 'admin_menu', 'sccss_register_submenu_page' );
 
@@ -83,6 +83,15 @@ function sccss_register_settings() {
 	register_setting( 'sccss_settings_group', 'sccss_settings' );
 }
 add_action( 'admin_init', 'sccss_register_settings' );
+
+
+/**
+ * Filter settings capability
+ */
+function sccss_filter_capability() {
+	return apply_filters( 'sccss_capability', 'edit_theme_options' );
+}
+add_filter( 'option_page_capability_sccss_settings_group', 'sccss_filter_capability' );
 
 
 /**


### PR DESCRIPTION
Adds a filter, sccss_capability, that lets developers change the required capability to use the plugin. Also fixes a "Cheatin' uh" error if a user with edit_theme_options but not manage_options tries to save the CSS. It does this by returning the filtered capability in the option_page_capability_ hook.