### PR TITLE
Fix AMP compatibility

### DIFF
--- a/includes/public.php
+++ b/includes/public.php
@@ -13,6 +13,18 @@ if ( ! defined( 'SCCSS_FILE' ) ) {
 }
 
 /**
+ * Add frontend hooks.
+ */
+function sccss_add_frontend_hooks() {
+	if ( sccss_is_amp_request() ) { // @todo Why not just do this all the time?
+		add_action( 'wp_head', 'sccss_print_inline_css' );
+	} else {
+		add_action( 'wp_enqueue_scripts', 'sccss_register_style', 99 );
+	}
+}
+add_action( 'wp', 'sccss_add_frontend_hooks' );
+
+/**
  * Enqueue link to add CSS through PHP.
  *
  * This is a typical WP Enqueue statement, except that the URL of the stylesheet is simply a query var.
@@ -43,8 +55,6 @@ function sccss_register_style() {
 	wp_enqueue_style( 'sccss_style' );
 }
 
-add_action( 'wp_enqueue_scripts', 'sccss_register_style', 99 );
-
 /**
  * If the query var is set, print the Simple Custom CSS rules.
  *
@@ -69,6 +79,17 @@ function sccss_maybe_print_css() {
 add_action( 'plugins_loaded', 'sccss_maybe_print_css' );
 
 /**
+ * Print inline style element.
+ *
+ * @see wp_custom_css_cb()
+ */
+function sccss_print_inline_css() {
+	echo '<style id="sccss">';
+	sccss_the_css();
+	echo '</style>';
+}
+
+/**
  * Echo the CSS.
  *
  * @since 4.0.0
@@ -78,5 +99,18 @@ function sccss_the_css() {
 	$raw_content = isset( $options['sccss-content'] ) ? $options['sccss-content'] : '';
 	$content     = wp_kses( $raw_content, array( '\'', '\"' ) );
 	$content     = str_replace( '&gt;', '>', $content );
-	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput
+	echo strip_tags( $content ); // phpcs:ignore WordPress.Security.EscapeOutput
+}
+
+/**
+ * Determine whether an AMP page is being requested.
+ *
+ * @return bool
+ */
+function sccss_is_amp_request() {
+	return (
+		( function_exists( 'amp_is_request' ) && amp_is_request() )
+		||
+		( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() )
+	);
 }

--- a/includes/public.php
+++ b/includes/public.php
@@ -42,6 +42,7 @@ function sccss_register_style() {
 		$url = home_url( '/', 'https' );
 	}
 
+	// @todo The ver should be set to the timestamp that the CSS was last edited.
 	wp_register_style( // phpcs:ignore WordPress.WP.EnqueuedResourceParameters
 		'sccss_style',
 		add_query_arg(
@@ -70,6 +71,7 @@ function sccss_maybe_print_css() {
 	}
 
 	ob_start();
+	// @todo Send Cache-Control header and ETag header.
 	header( 'Content-type: text/css' );
 
 	sccss_the_css();


### PR DESCRIPTION
Hey John! I hope you are well.

A user on the AMP plugin forum opened a [topic](https://wordpress.org/support/topic/rebuil-amp-custom-css/) in which they said that changes to the CSS in your plugin were not getting picked up on the AMP pages. The reason for this is that your plugin is outputting the CSS via an external stylesheet link, and the AMP plugin will cache those stylesheets for performance to avoid needing to to an HTTP loopback request to fetch the contents to inline them for the AMP page. So this PR opts to inline the CSS from the start on AMP pages to avoid that additional loopback request as well as the caching problem.

Nevertheless, I wonder why the CSS is not just always inlined? This is what core is doing with the Additional CSS feature. See [`wp_custom_css_cb()`](https://developer.wordpress.org/reference/functions/wp_custom_css_cb/). This will improve performance because at the moment the requests to `?sccss=1` are not sending any `Cache-Control` headers in the response, meaning that such stylesheets will need to be re-fetched with each request. Stylesheets block rendering so this will slow down sites.